### PR TITLE
Add basic machine vs machine demo

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -1,0 +1,23 @@
+module Main where
+
+import Board
+import GameLogic
+import Types
+
+-- | Run a simple machine vs machine game for the given number of turns.
+playGame :: Int -> GameState -> IO ()
+playGame 0 gs = putStrLn $ showBoard (board gs)
+playGame n gs = do
+  putStrLn $ "Turn: " ++ show (turns - n)
+  putStrLn $ showBoard (board gs)
+  step <- randomStep gs
+  case step of
+    Nothing   -> putStrLn "Game over"
+    Just gs' -> playGame (n-1) gs'
+  where
+    turns = n
+
+main :: IO ()
+main = do
+  putStrLn "Machine vs Machine demo"
+  playGame 20 initialState

--- a/damas.cabal
+++ b/damas.cabal
@@ -1,0 +1,10 @@
+cabal-version:       >=1.10
+name:                damas
+version:             0.1.0.0
+build-type:          Simple
+
+executable damas
+  main-is:             Main.hs
+  hs-source-dirs:      app src
+  default-language:    Haskell2010
+  build-depends:       base >=4.7 && <5, random

--- a/src/Board.hs
+++ b/src/Board.hs
@@ -1,0 +1,33 @@
+module Board
+  ( initialBoard
+  , showBoard
+  ) where
+
+import Types
+
+-- | Size of the board (standard 8x8 checkers board).
+boardSize :: Int
+boardSize = 8
+
+-- | Initialize the standard starting board.
+initialBoard :: Board
+initialBoard = [ initialRow r | r <- [0..boardSize-1] ]
+  where
+    initialRow r
+      | r <= 2    = [ pieceFor Black r c | c <- [0..boardSize-1] ]
+      | r >= 5    = [ pieceFor Red   r c | c <- [0..boardSize-1] ]
+      | otherwise = replicate boardSize Empty
+    pieceFor p r c
+      | (r + c) `mod` 2 == 1 = Man p
+      | otherwise            = Empty
+
+-- | Pretty print the board.
+showBoard :: Board -> String
+showBoard b = unlines $ map showRow b
+  where
+    showRow = concatMap showPiece
+    showPiece (Man Red)   = " r"
+    showPiece (Man Black) = " b"
+    showPiece (King Red)  = " R"
+    showPiece (King Black)= " B"
+    showPiece Empty       = " ."

--- a/src/GameLogic.hs
+++ b/src/GameLogic.hs
@@ -1,0 +1,32 @@
+module GameLogic
+  ( initialState
+  , randomStep
+  ) where
+
+import System.Random (randomRIO)
+import Types
+import Board
+import Moves
+
+-- | Create the initial game state.
+initialState :: GameState
+initialState = GameState initialBoard Red
+
+-- | Apply a move to the board.
+applyMove :: Board -> Move -> Board
+applyMove b (Move (r,c) (r',c')) = replace2 r' c' (b !! r !! c) $ replace2 r c Empty b
+  where
+    replace2 x y val rows = take x rows ++ [replace y val (rows !! x)] ++ drop (x+1) rows
+    replace idx v row = take idx row ++ [v] ++ drop (idx+1) row
+
+-- | Perform a random valid move for the current player.
+-- Returns Nothing if there are no moves available.
+randomStep :: GameState -> IO (Maybe GameState)
+randomStep gs = case validMoves gs of
+  []    -> return Nothing
+  moves -> do
+    idx <- randomRIO (0, length moves - 1)
+    let mv = moves !! idx
+        newBoard = applyMove (board gs) mv
+        nextPlayer = if currentPlayer gs == Red then Black else Red
+    return $ Just gs { board = newBoard, currentPlayer = nextPlayer }

--- a/src/Moves.hs
+++ b/src/Moves.hs
@@ -1,0 +1,34 @@
+module Moves
+  ( validMoves
+  ) where
+
+import Types
+import Board (boardSize)
+
+-- | Generate basic diagonal moves (without capturing).
+-- Only forward moves for men are considered.
+validMoves :: GameState -> [Move]
+validMoves gs = concatMap pieceMoves positions
+  where
+    b = board gs
+    positions = [ ((r,c), p)
+                | r <- [0..boardSize-1]
+                , c <- [0..boardSize-1]
+                , let p = b !! r !! c
+                , piecePlayer p == Just (currentPlayer gs)
+                ]
+    pieceMoves ((r,c), Man Red)   = simpleMoves [(r-1,c-1),(r-1,c+1)]
+    pieceMoves ((r,c), Man Black) = simpleMoves [(r+1,c-1),(r+1,c+1)]
+    pieceMoves ((r,c), King _)    = simpleMoves [(r-1,c-1),(r-1,c+1),(r+1,c-1),(r+1,c+1)]
+    pieceMoves _ = []
+    simpleMoves coords = [ Move (r,c) coord
+                         | coord@(nr,nc) <- coords
+                         , inBounds coord
+                         , b !! nr !! nc == Empty
+                         ]
+    inBounds (x,y) = x >= 0 && x < boardSize && y >=0 && y < boardSize
+
+piecePlayer :: Piece -> Maybe Player
+piecePlayer (Man p)  = Just p
+piecePlayer (King p) = Just p
+piecePlayer _        = Nothing

--- a/src/Types.hs
+++ b/src/Types.hs
@@ -1,0 +1,22 @@
+module Types where
+
+-- | Represents the two players of the game.
+data Player = Red | Black deriving (Eq, Show)
+
+-- | A piece on the board can be a man or a king of a specific player,
+-- or the square can be empty.
+data Piece = Man Player | King Player | Empty deriving (Eq, Show)
+
+type Position = (Int, Int)
+
+-- | Board is represented as rows of pieces.
+type Board = [[Piece]]
+
+-- | Represents a move from one position to another.
+data Move = Move Position Position deriving (Eq, Show)
+
+-- | Holds the current state of the game.
+data GameState = GameState
+  { board :: Board
+  , currentPlayer :: Player
+  } deriving (Show)

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,3 @@
+resolver: lts-20.0
+packages:
+- .


### PR DESCRIPTION
## Summary
- implement simple board representation and initial board
- provide move generation and random AI logic
- create a minimal executable that runs a machine vs machine demo
- add cabal and stack configuration

## Testing
- `ghc -o damas app/Main.hs` *(fails: command not found)*
- `cabal build` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c0eaa42b8832a8e0f0532c9fa0a99